### PR TITLE
docs: fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Key features include:
 
 To install the module in your Go project:
 ```bash
-$ go get github.com/krakenfx/api-go
+go get github.com/krakenfx/api-go/...
 ```
 
 If you're interested in running examples or contributing to development, clone the repo and install dependencies:


### PR DESCRIPTION
Since we are using subpackages, the spot, derivatives, and kraken packages won't be imported by simply doing:
```bash
go get github.com/krakenfx/api-go
```

We need to use instead:
```bash
go get github.com/krakenfx/api-go/...
```