### PR TITLE
fix: use auth for GetWebSocketsToken

### DIFF
--- a/pkg/spot/rest.go
+++ b/pkg/spot/rest.go
@@ -490,6 +490,7 @@ func NewREST() *REST {
 	})
 	rest.GetWebSocketsToken = NewAPIFunctionWithNoParams[GetWebSocketsTokenResult](&APIFunctionOptions{
 		REST:   rest,
+		Auth:   true,
 		Method: "POST",
 		Path:   "/0/private/GetWebSocketsToken",
 	})


### PR DESCRIPTION
This PR updates the GetWebSocketsToken API function to explicitly require authentication.

Currently, the GetWebSocketsToken function is missing the `Auth: true` property.

Since this endpoint is part of the private API, it requires proper authentication headers. Without this flag, invocation would fail with authentication errors.