### PR TITLE
ci: add go tests to workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -40,3 +40,6 @@ jobs:
         with:
           version: latest
           args: --timeout=1m 
+      
+      - name: Run Go Tests
+        run: go test ./...


### PR DESCRIPTION
This PR adds an step to run `go test ./...` during the lint job.