### PR TITLE
chore: rename go module to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Key features include:
 
 To install the module in your Go project:
 ```bash
-go get github.com/krakenfx/api-go/...
+go get github.com/krakenfx/api-go/v2/...
 ```
 
 If you're interested in running examples or contributing to development, clone the repo and install dependencies:

--- a/examples/futuresrest/accounts/main.go
+++ b/examples/futuresrest/accounts/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
 )
 
 func main() {

--- a/examples/futuresrest/batchorder/batchorder.go
+++ b/examples/futuresrest/batchorder/batchorder.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/decimal"
-	"github.com/krakenfx/api-go/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
 )
 
 // Derivative contract.

--- a/examples/futuresrest/instruments/instruments.go
+++ b/examples/futuresrest/instruments/instruments.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/pkg/decimal"
-	"github.com/krakenfx/api-go/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
 )
 
 func main() {

--- a/examples/futuresrest/openorders/openorders.go
+++ b/examples/futuresrest/openorders/openorders.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/pkg/decimal"
-	"github.com/krakenfx/api-go/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
 )
 
 func main() {

--- a/examples/futuresrest/orderbook/orderbook.go
+++ b/examples/futuresrest/orderbook/orderbook.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/pkg/decimal"
-	"github.com/krakenfx/api-go/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
 )
 
 // Derivative contract.

--- a/examples/futuresrest/ordermgmt/ordermgmt.go
+++ b/examples/futuresrest/ordermgmt/ordermgmt.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/decimal"
-	"github.com/krakenfx/api-go/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
 )
 
 // Derivative contract.

--- a/examples/futuresrest/tickers/tickers.go
+++ b/examples/futuresrest/tickers/tickers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
 )
 
 func main() {

--- a/examples/futuresrest/tickersymbol/tickersymbol.go
+++ b/examples/futuresrest/tickersymbol/tickersymbol.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
 )
 
 // Derivative contract.

--- a/examples/futuresrest/tradehistory/tradehistory.go
+++ b/examples/futuresrest/tradehistory/tradehistory.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
 )
 
 // Derivative contract.

--- a/examples/futuresws/balances/balances.go
+++ b/examples/futuresws/balances/balances.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/derivatives"
-	"github.com/krakenfx/api-go/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
 )
 
 func main() {

--- a/examples/futuresws/book/book.go
+++ b/examples/futuresws/book/book.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/book"
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/derivatives"
-	"github.com/krakenfx/api-go/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/book"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
 )
 
 var contract string = "PF_XBTUSD"

--- a/examples/futuresws/maintenance/maintenance.go
+++ b/examples/futuresws/maintenance/maintenance.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/derivatives"
-	"github.com/krakenfx/api-go/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
 )
 
 func main() {

--- a/examples/futuresws/marketdata/marketdata.go
+++ b/examples/futuresws/marketdata/marketdata.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/derivatives"
-	"github.com/krakenfx/api-go/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
 )
 
 // Derivative contract

--- a/examples/futuresws/openorders/openorders.go
+++ b/examples/futuresws/openorders/openorders.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/derivatives"
-	"github.com/krakenfx/api-go/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/derivatives"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
 )
 
 func main() {

--- a/examples/spotrest/balance/balance.go
+++ b/examples/spotrest/balance/balance.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/pkg/spot"
+	"github.com/krakenfx/api-go/v2/pkg/spot"
 )
 
 func main() {

--- a/examples/spotrest/batchmgmt/batchmgmt.go
+++ b/examples/spotrest/batchmgmt/batchmgmt.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/decimal"
-	"github.com/krakenfx/api-go/pkg/spot"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/spot"
 )
 
 // Spot market to trade from.

--- a/examples/spotrest/marketdata/marketdata.go
+++ b/examples/spotrest/marketdata/marketdata.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/spot"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/spot"
 )
 
 func main() {

--- a/examples/spotrest/normalize/normalize.go
+++ b/examples/spotrest/normalize/normalize.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/pkg/spot"
+	"github.com/krakenfx/api-go/v2/pkg/spot"
 )
 
 func main() {

--- a/examples/spotrest/recenttrades/recenttrades.go
+++ b/examples/spotrest/recenttrades/recenttrades.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/spot"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/spot"
 )
 
 func main() {

--- a/examples/spotrest/withdrawmethods/withdrawmethods.go
+++ b/examples/spotrest/withdrawmethods/withdrawmethods.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/spot"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/spot"
 )
 
 func main() {

--- a/examples/spotws/accountdata/accountdata.go
+++ b/examples/spotws/accountdata/accountdata.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/kraken"
-	"github.com/krakenfx/api-go/pkg/spot"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/pkg/spot"
 )
 
 func main() {

--- a/examples/spotws/l2/l2.go
+++ b/examples/spotws/l2/l2.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/book"
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/kraken"
-	"github.com/krakenfx/api-go/pkg/spot"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/book"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/pkg/spot"
 )
 
 func main() {

--- a/examples/spotws/l3/l3.go
+++ b/examples/spotws/l3/l3.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/book"
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/kraken"
-	"github.com/krakenfx/api-go/pkg/spot"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/book"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/pkg/spot"
 )
 
 func main() {

--- a/examples/spotws/marketdata/marketdata.go
+++ b/examples/spotws/marketdata/marketdata.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/kraken"
-	"github.com/krakenfx/api-go/pkg/spot"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/pkg/spot"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/krakenfx/api-go
+module github.com/krakenfx/api-go/v2
 
 go 1.23.2
 

--- a/pkg/book/book.go
+++ b/pkg/book/book.go
@@ -4,8 +4,8 @@ import (
 	"math"
 	"time"
 
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
 )
 
 // Order book structure for L2 and L3.

--- a/pkg/book/level.go
+++ b/pkg/book/level.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/krakenfx/api-go/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
 )
 
 // Level contains price level information.

--- a/pkg/book/side.go
+++ b/pkg/book/side.go
@@ -3,7 +3,7 @@ package book
 import (
 	"sync"
 
-	"github.com/krakenfx/api-go/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
 )
 
 // Side encompasses the price levels in one side of the book.

--- a/pkg/derivatives/books.go
+++ b/pkg/derivatives/books.go
@@ -8,11 +8,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/book"
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/decimal"
-	"github.com/krakenfx/api-go/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/book"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
 )
 
 // BookManager manages the lifecycle of a collection of [Book] structs.

--- a/pkg/derivatives/entities.go
+++ b/pkg/derivatives/entities.go
@@ -3,7 +3,7 @@ package derivatives
 import (
 	"time"
 
-	"github.com/krakenfx/api-go/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
 )
 
 type MarginSchedule struct {

--- a/pkg/derivatives/normalizer.go
+++ b/pkg/derivatives/normalizer.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/krakenfx/api-go/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
 )
 
 // Normalizer provides helper methods for a group of [Instrument] objects.

--- a/pkg/derivatives/rest.go
+++ b/pkg/derivatives/rest.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
 )
 
 // REST wraps [RESTBase] with functions to call common endpoints.

--- a/pkg/derivatives/websocketbase.go
+++ b/pkg/derivatives/websocketbase.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
 )
 
 // WebSocketBase is the underlying of the [WebSocket] client.

--- a/pkg/kraken/rest.go
+++ b/pkg/kraken/rest.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/krakenfx/api-go/internal/helper"
+	"github.com/krakenfx/api-go/v2/internal/helper"
 )
 
 // Request is a wrapper around [http.Request] to assist with internal functions.

--- a/pkg/kraken/websocket.go
+++ b/pkg/kraken/websocket.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/krakenfx/api-go/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
 )
 
 // WebSocket implements a common structure for the WebSocket APIs.

--- a/pkg/spot/books.go
+++ b/pkg/spot/books.go
@@ -8,11 +8,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/book"
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/decimal"
-	"github.com/krakenfx/api-go/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/book"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
 )
 
 // BookManager manages the lifecycle of a collection of [Book] structs.

--- a/pkg/spot/entities.go
+++ b/pkg/spot/entities.go
@@ -1,6 +1,6 @@
 package spot
 
-import "github.com/krakenfx/api-go/pkg/decimal"
+import "github.com/krakenfx/api-go/v2/pkg/decimal"
 
 type FullName struct {
 	FirstName  string `json:"first_name,omitempty"`

--- a/pkg/spot/normalizer.go
+++ b/pkg/spot/normalizer.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/krakenfx/api-go/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/pkg/spot/rest.go
+++ b/pkg/spot/rest.go
@@ -9,9 +9,9 @@ import (
 	"maps"
 	"reflect"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/decimal"
-	"github.com/krakenfx/api-go/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
 )
 
 // REST wraps [RESTBase] with functions to call common endpoints.

--- a/pkg/spot/websocket.go
+++ b/pkg/spot/websocket.go
@@ -1,7 +1,7 @@
 package spot
 
 import (
-	"github.com/krakenfx/api-go/internal/helper"
+	"github.com/krakenfx/api-go/v2/internal/helper"
 )
 
 // WebSocket wraps a [WebSocketBase] struct with order management and subscription request functions.

--- a/pkg/spot/websocketbase.go
+++ b/pkg/spot/websocketbase.go
@@ -3,9 +3,9 @@ package spot
 import (
 	"fmt"
 
-	"github.com/krakenfx/api-go/internal/helper"
-	"github.com/krakenfx/api-go/pkg/callback"
-	"github.com/krakenfx/api-go/pkg/kraken"
+	"github.com/krakenfx/api-go/v2/internal/helper"
+	"github.com/krakenfx/api-go/v2/pkg/callback"
+	"github.com/krakenfx/api-go/v2/pkg/kraken"
 )
 
 // WebSocketBase is the underlying of the [WebSocket] client.


### PR DESCRIPTION
This PR renames the module to v2 to avoid experiencing breaking changes when running `go get -u github.com/krakenfx/api-go/...` when we release it.