### PR TITLE
feat: convert 2d array into slice of structs

### DIFF
--- a/examples/futuresrest/orderbook/orderbook.go
+++ b/examples/futuresrest/orderbook/orderbook.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/krakenfx/api-go/v2/pkg/decimal"
+	"github.com/krakenfx/api-go/v2/internal/helper"
 	"github.com/krakenfx/api-go/v2/pkg/derivatives"
 )
 
@@ -20,9 +20,9 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	for _, side := range [][][]*decimal.Decimal{resp.Result.OrderBook.Asks, resp.Result.OrderBook.Bids} {
+	for _, side := range [][]derivatives.PriceLevel{resp.Result.OrderBook.Asks, resp.Result.OrderBook.Bids} {
 		for i := 9; i >= 0 && i < len(side); i-- {
-			fmt.Printf("%s - %s\n", side[i][0], side[i][1])
+			fmt.Println(helper.ToJSON(side[i]))
 		}
 		fmt.Printf("---\n")
 	}

--- a/pkg/derivatives/entities.go
+++ b/pkg/derivatives/entities.go
@@ -84,17 +84,15 @@ func (job JSONOrderBook) OrderBook() (book OrderBook) {
 	book.Asks = make([]PriceLevel, len(job.Asks))
 	for i, ask := range job.Asks {
 		book.Asks[i] = PriceLevel{
-			Price:     ask[0],
-			Volume:    ask[1],
-			Timestamp: time.Unix(ask[2].Int64(), 0),
+			Price:  ask[0],
+			Volume: ask[1],
 		}
 	}
 	book.Bids = make([]PriceLevel, len(job.Bids))
 	for i, bid := range job.Bids {
 		book.Bids[i] = PriceLevel{
-			Price:     bid[0],
-			Volume:    bid[1],
-			Timestamp: time.Unix(bid[2].Int64(), 0),
+			Price:  bid[0],
+			Volume: bid[1],
 		}
 	}
 	return
@@ -115,9 +113,8 @@ func (ob *OrderBook) UnmarshalJSON(data []byte) error {
 }
 
 type PriceLevel struct {
-	Price     *decimal.Decimal `json:"price,omitempty"`
-	Volume    *decimal.Decimal `json:"volume,omitempty"`
-	Timestamp time.Time        `json:"timestamp,omitempty"`
+	Price  *decimal.Decimal `json:"price,omitempty"`
+	Volume *decimal.Decimal `json:"volume,omitempty"`
 }
 
 type Trade struct {

--- a/pkg/derivatives/entities.go
+++ b/pkg/derivatives/entities.go
@@ -1,6 +1,7 @@
 package derivatives
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/krakenfx/api-go/v2/pkg/decimal"
@@ -74,9 +75,49 @@ type TickerData struct {
 	Change24h             *decimal.Decimal `json:"change24h,omitempty"`
 }
 
-type OrderBook struct {
+type JSONOrderBook struct {
 	Asks [][]*decimal.Decimal `json:"asks,omitempty"`
 	Bids [][]*decimal.Decimal `json:"bids,omitempty"`
+}
+
+func (job JSONOrderBook) OrderBook() (book OrderBook) {
+	book.Asks = make([]PriceLevel, len(job.Asks))
+	for i, ask := range job.Asks {
+		book.Asks[i] = PriceLevel{
+			Price:     ask[0],
+			Volume:    ask[1],
+			Timestamp: time.Unix(ask[2].Int64(), 0),
+		}
+	}
+	book.Bids = make([]PriceLevel, len(job.Bids))
+	for i, bid := range job.Bids {
+		book.Bids[i] = PriceLevel{
+			Price:     bid[0],
+			Volume:    bid[1],
+			Timestamp: time.Unix(bid[2].Int64(), 0),
+		}
+	}
+	return
+}
+
+type OrderBook struct {
+	Asks []PriceLevel `json:"asks,omitempty"`
+	Bids []PriceLevel `json:"bids,omitempty"`
+}
+
+func (ob *OrderBook) UnmarshalJSON(data []byte) error {
+	var v JSONOrderBook
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	*ob = v.OrderBook()
+	return nil
+}
+
+type PriceLevel struct {
+	Price     *decimal.Decimal `json:"price,omitempty"`
+	Volume    *decimal.Decimal `json:"volume,omitempty"`
+	Timestamp time.Time        `json:"timestamp,omitempty"`
 }
 
 type Trade struct {

--- a/pkg/spot/entities.go
+++ b/pkg/spot/entities.go
@@ -1,6 +1,11 @@
 package spot
 
-import "github.com/krakenfx/api-go/v2/pkg/decimal"
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/krakenfx/api-go/v2/pkg/decimal"
+)
 
 type FullName struct {
 	FirstName  string `json:"first_name,omitempty"`
@@ -23,19 +28,19 @@ type Residence struct {
 }
 
 type UserInfo struct {
-	Email              string     `json:"email,omitempty"`
-	ExternalID         string     `json:"external_id,omitempty"`
-	TOSVersionAccepted int        `json:"tos_version_accepted,omitempty"`
-	FullName           *FullName  `json:"full_name,omitempty"`
-	DateOfBirth        string     `json:"date_of_birth,omitempty"`
-	Residence          *Residence `json:"residence,omitempty"`
-	Phone              string     `json:"phone,omitempty"`
-	Nationalities      []string   `json:"nationalities,omitempty"`
-	Occupation         string     `json:"occupation,omitempty"`
-	CityOfBirth        string     `json:"city_of_birth,omitempty"`
-	CountryOfBirth     string     `json:"country_of_birth,omitempty"`
-	TaxIDs             []*TaxID   `json:"tax_ids,omitempty"`
-	Language           string     `json:"language,omitempty"`
+	Email              string    `json:"email,omitempty"`
+	ExternalID         string    `json:"external_id,omitempty"`
+	TOSVersionAccepted int       `json:"tos_version_accepted,omitempty"`
+	FullName           FullName  `json:"full_name,omitempty"`
+	DateOfBirth        string    `json:"date_of_birth,omitempty"`
+	Residence          Residence `json:"residence,omitempty"`
+	Phone              string    `json:"phone,omitempty"`
+	Nationalities      []string  `json:"nationalities,omitempty"`
+	Occupation         string    `json:"occupation,omitempty"`
+	CityOfBirth        string    `json:"city_of_birth,omitempty"`
+	CountryOfBirth     string    `json:"country_of_birth,omitempty"`
+	TaxIDs             []TaxID   `json:"tax_ids,omitempty"`
+	Language           string    `json:"language,omitempty"`
 }
 
 type ActionDetailsType struct {
@@ -53,14 +58,14 @@ type UserRequiredAction struct {
 }
 
 type UserStatus struct {
-	State           string                `json:"state,omitempty"`
-	Reasons         []string              `json:"reasons,omitempty"`
-	RequiredActions []*UserRequiredAction `json:"required_actions,omitempty"`
+	State           string               `json:"state,omitempty"`
+	Reasons         []string             `json:"reasons,omitempty"`
+	RequiredActions []UserRequiredAction `json:"required_actions,omitempty"`
 }
 
 type Identity struct {
-	FullName    *FullName `json:"full_name,omitempty"`
-	DateOfBirth string    `json:"date_of_birth,omitempty"`
+	FullName    FullName `json:"full_name,omitempty"`
+	DateOfBirth string   `json:"date_of_birth,omitempty"`
 }
 
 type Watchlist struct {
@@ -73,7 +78,7 @@ type Watchlist struct {
 }
 
 type VerificationMetadata struct {
-	Identity               *Identity  `json:"identity,omitempty"`
+	Identity               Identity   `json:"identity,omitempty"`
 	Address                *Residence `json:"address,omitempty"`
 	Sanctions              *Watchlist `json:"sanctions,omitempty"`
 	NegativeNews           *Watchlist `json:"negative_news,omitempty"`

--- a/pkg/spot/entities.go
+++ b/pkg/spot/entities.go
@@ -485,15 +485,15 @@ type EarnStrategyAPR struct {
 	High string `json:"high,omitempty"`
 }
 type EarnStrategyLockType struct {
-	Type                    string           `json:"type,omitempty"`
-	BondingPeriod           *decimal.Decimal `json:"bonding_period,omitempty"`
-	BondingPeriodVariable   bool             `json:"bonding_period_variable,omitempty"`
-	BondingRewards          bool             `json:"bonding_rewards,omitempty"`
-	ExitQueuePeriod         *decimal.Decimal `json:"exit_queue_period"`
-	PayoutFrequency         *decimal.Decimal `json:"payout_frequency,omitempty"`
-	UnbondingPeriod         *decimal.Decimal `json:"unbonding_period,omitempty"`
-	UnbondingPeriodVariable bool             `json:"unbonding_period_variable,omitempty"`
-	UnbondingRewards        bool             `json:"unbonding_rewards,omitempty"`
+	Type                    string `json:"type,omitempty"`
+	BondingPeriod           int    `json:"bonding_period,omitempty"`
+	BondingPeriodVariable   bool   `json:"bonding_period_variable,omitempty"`
+	BondingRewards          bool   `json:"bonding_rewards,omitempty"`
+	ExitQueuePeriod         int    `json:"exit_queue_period"`
+	PayoutFrequency         int    `json:"payout_frequency,omitempty"`
+	UnbondingPeriod         int    `json:"unbonding_period,omitempty"`
+	UnbondingPeriodVariable bool   `json:"unbonding_period_variable,omitempty"`
+	UnbondingRewards        bool   `json:"unbonding_rewards,omitempty"`
 }
 
 type EarnStrategyYieldSource struct {
@@ -510,7 +510,7 @@ type EarnStrategy struct {
 	Asset                     string                   `json:"asset,omitempty"`
 	LockType                  EarnStrategyLockType     `json:"lock_type,omitempty"`
 	AprEstimate               *EarnStrategyAPR         `json:"apr_estimate,omitempty"`
-	UserMinAllocation         string                   `json:"user_min_allocation,omitempty"`
+	UserMinAllocation         *decimal.Decimal         `json:"user_min_allocation,omitempty"`
 	AllocationFee             *decimal.Decimal         `json:"allocation_fee,omitempty"`
 	DeallocationFee           *decimal.Decimal         `json:"deallocation_fee,omitempty"`
 	AutoCompound              EarnStrategyAutoCompound `json:"auto_compound,omitempty"`
@@ -521,38 +521,38 @@ type EarnStrategy struct {
 }
 
 type EarnAllocationReward struct {
-	Native    string `json:"native"`
-	Converted string `json:"converted"`
+	Native    *decimal.Decimal `json:"native"`
+	Converted *decimal.Decimal `json:"converted"`
 }
 type EarnAllocationAmountState struct {
-	Native          string                       `json:"native,omitempty"`
-	Converted       string                       `json:"converted,omitempty"`
-	AllocationCount int                          `json:"allocation_count,omitempty"`
-	Allocations     []*EarnAllocationStateDetail `json:"allocations,omitempty"`
+	Native          *decimal.Decimal            `json:"native,omitempty"`
+	Converted       *decimal.Decimal            `json:"converted,omitempty"`
+	AllocationCount int                         `json:"allocation_count,omitempty"`
+	Allocations     []EarnAllocationStateDetail `json:"allocations,omitempty"`
 }
 type EarnAllocationStateDetail struct {
-	Native    string `json:"native,omitempty"`
-	Converted string `json:"converted,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	Expires   string `json:"expires,omitempty"`
+	Native    string    `json:"native,omitempty"`
+	Converted time.Time `json:"converted,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	Expires   time.Time `json:"expires,omitempty"`
 }
 type EarnAllocationAmount struct {
-	Bonding   *EarnAllocationAmountState `json:"bonding,omitempty"`
-	ExitQueue *EarnAllocationAmountState `json:"exit_queue,omitempty"`
-	Pending   *EarnAllocationAmountState `json:"pending,omitempty"`
-	Total     *EarnAllocationAmountState `json:"total,omitempty"`
-	Unbonding *EarnAllocationAmountState `json:"unbonding,omitempty"`
+	Bonding   EarnAllocationAmountState `json:"bonding,omitempty"`
+	ExitQueue EarnAllocationAmountState `json:"exit_queue,omitempty"`
+	Pending   EarnAllocationAmountState `json:"pending,omitempty"`
+	Total     EarnAllocationAmountState `json:"total,omitempty"`
+	Unbonding EarnAllocationAmountState `json:"unbonding,omitempty"`
 }
 type EarnAllocationPayout struct {
-	AccumulatedReward *EarnAllocationReward `json:"accumulated_reward,omitempty"`
-	EstimatedReward   *EarnAllocationReward `json:"estimated_reward,omitempty"`
-	PeriodStart       string                `json:"period_start,omitempty"`
-	PeriodEnd         string                `json:"period_end,omitempty"`
+	AccumulatedReward EarnAllocationReward `json:"accumulated_reward,omitempty"`
+	EstimatedReward   EarnAllocationReward `json:"estimated_reward,omitempty"`
+	PeriodStart       string               `json:"period_start,omitempty"`
+	PeriodEnd         string               `json:"period_end,omitempty"`
 }
 type EarnAllocation struct {
-	StrategyID      string                `json:"strategy_id,omitempty"`
-	NativeAsset     string                `json:"native_asset,omitempty"`
-	AmountAllocated EarnAllocationAmount  `json:"amount_allocated,omitempty"`
-	TotalRewarded   EarnAllocationReward  `json:"total_rewarded,omitempty"`
-	Payout          *EarnAllocationPayout `json:"payout,omitempty"`
+	StrategyID      string               `json:"strategy_id,omitempty"`
+	NativeAsset     string               `json:"native_asset,omitempty"`
+	AmountAllocated EarnAllocationAmount `json:"amount_allocated,omitempty"`
+	TotalRewarded   EarnAllocationReward `json:"total_rewarded,omitempty"`
+	Payout          EarnAllocationPayout `json:"payout,omitempty"`
 }


### PR DESCRIPTION
This PR introduces struct-based representations for entities previously modeled as 2D slices, especially for order books and asset pairs. This improves type safety, data validation, and downstream usability throughout the codebase.